### PR TITLE
sepolicy: remove adsp access rule for sensors.qti

### DIFF
--- a/generic/vendor/common/file_contexts
+++ b/generic/vendor/common/file_contexts
@@ -121,8 +121,7 @@
 /vendor/bin/hw/android\.hardware\.biometrics\.fingerprint@2\.1-service\.fpc u:object_r:hal_fingerprint_default_exec:s0
 /vendor/bin/hw/android.hardware.thermal@2.0-service.qti      u:object_r:hal_thermal_default_exec:s0
 /vendor/bin/thermal-engine      u:object_r:vendor_thermal-engine_exec:s0
-/vendor/bin/sensors.qcom        u:object_r:vendor_sensors_exec:s0
-/vendor/bin/sensors.qti         u:object_r:vendor_sensors_exec:s0
+/vendor/bin/sensors.qti         u:object_r:vendor_sensors_qti_exec:s0
 /vendor/bin/ssr_setup           u:object_r:vendor_ssr_setup_exec:s0
 /vendor/bin/ssr_diag            u:object_r:vendor_ssr_diag_exec:s0
 /vendor/bin/pm-service          u:object_r:vendor_per_mgr_exec:s0

--- a/generic/vendor/common/sensors_qti.te
+++ b/generic/vendor/common/sensors_qti.te
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, The Linux Foundation. All rights reserved.
+# Copyright (c) 2018-2021, The Linux Foundation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -25,43 +25,34 @@
 # OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # Policy for sensor daemon
-type vendor_sensors, domain;
-type vendor_sensors_exec, exec_type, vendor_file_type, file_type;
+type vendor_sensors_qti, domain;
+type vendor_sensors_qti_exec, exec_type, vendor_file_type, file_type;
 
-init_daemon_domain(vendor_sensors)
-get_prop(vendor_sensors, vendor_sensors_prop)
+init_daemon_domain(vendor_sensors_qti)
+get_prop(vendor_sensors_qti, vendor_sensors_prop)
 
-allow vendor_sensors self:capability {
-    setuid
-    setgid
-    net_bind_service
-};
 
-allow vendor_sensors self:{ socket qipcrtr_socket } create_socket_perms;
+# Access to tests from userdebug/eng builds
+userdebug_or_eng(`
+  diag_use(vendor_sensors_qti)
+  get_prop(vendor_sensors_qti, vendor_sensors_dbg_prop)
+
+  #allow starting of diag_mdlog
+  allow vendor_sensors_qti vendor_qlogd_exec:file rx_file_perms;
+  allow vendor_sensors_qti vendor_shell_exec:file rx_file_perms;
+')
+
+allow vendor_sensors_qti self:{ socket qipcrtr_socket } create_socket_perms;
 # ioctlcmd=c304
-allowxperm vendor_sensors self:{ socket qipcrtr_socket } ioctl msm_sock_ipc_ioctls;
+allowxperm vendor_sensors_qti self:{ socket qipcrtr_socket } ioctl msm_sock_ipc_ioctls;
 
-allow vendor_sensors mnt_vendor_file:dir r_dir_perms;
+allow vendor_sensors_qti mnt_vendor_file:dir r_dir_perms;
 
+allow vendor_sensors_qti vendor_sensors_vendor_data_file:dir create_dir_perms;
+allow vendor_sensors_qti vendor_sensors_vendor_data_file:file create_file_perms;
 
-allow vendor_sensors system_file:dir r_dir_perms;
-allow vendor_sensors sensors_device:chr_file rw_file_perms;
+allow vendor_sensors_qti vendor_sensors_vendor_data_file:fifo_file create_file_perms;
 
-allow vendor_sensors vendor_sysfs_soc:file w_file_perms;
-allow vendor_sensors vendor_sysfs_data:file r_file_perms;
-
-allow vendor_sensors ion_device:chr_file r_file_perms;
-allow vendor_sensors vendor_qdsp_device:chr_file r_file_perms;
-allow vendor_sensors vendor_xdsp_device:chr_file r_file_perms;
-
-# For reading dir/files on /dsp
-r_dir_file(vendor_sensors, adsprpcd_file)
-# For reading adsprpc_prop
-get_prop(vendor_sensors, vendor_adsprpc_prop)
-
-# Access to /persist/vendor_sensors
-allow vendor_sensors vendor_persist_sensors_file:dir create_dir_perms;
-allow vendor_sensors vendor_persist_sensors_file:file create_file_perms;
-
-# Access to wakelock sysfs
-wakelock_use(vendor_sensors)
+#Allow to search SSR node directory
+allow vendor_sensors_qti vendor_sysfs_slpi:dir search;
+allow vendor_sensors_qti vendor_sysfs_slpi:file getattr;


### PR DESCRIPTION
split rules for sensors.qti and sscrpcd

Change-Id: Iaf69bcefd08f195995cd67e12d3577c7b22f23ac